### PR TITLE
Enhance PoS switch with quantum support

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -120,9 +120,13 @@ public:
         consensus.fStrictChainId = true;
         consensus.fAllowLegacyBlocks = true;
         consensus.nHeightEffective = 0;
+        consensus.nPoSSwitchHeight = 20000000; // Hard fork: switch to PoS at this height
+        consensus.nPoSQuantumHeight = 20000002; // Enable quantum PoS at this height
 
         // Blocks 145000 - 371336 are Digishield without AuxPoW
         digishieldConsensus = consensus;
+        digishieldConsensus.nPoSSwitchHeight = consensus.nPoSSwitchHeight;
+        digishieldConsensus.nPoSQuantumHeight = consensus.nPoSQuantumHeight;
         digishieldConsensus.nHeightEffective = 15615200;
         digishieldConsensus.fSimplifiedRewards = true;
         digishieldConsensus.fDigishieldDifficultyCalculation = true;
@@ -131,6 +135,8 @@ public:
 
         // Blocks 371337+ are AuxPoW
         auxpowConsensus = digishieldConsensus;
+        auxpowConsensus.nPoSSwitchHeight = consensus.nPoSSwitchHeight;
+        auxpowConsensus.nPoSQuantumHeight = consensus.nPoSQuantumHeight;
         auxpowConsensus.nHeightEffective = 15615201;
         auxpowConsensus.fAllowLegacyBlocks = false;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -81,6 +81,12 @@ struct Params {
     bool fAllowLegacyBlocks;
 
     /** Height-aware consensus parameters */
+    /** Block height at which a temporary switch to PoS is activated. A value of
+     * 0 disables the feature. */
+    uint32_t nPoSSwitchHeight = 0;
+
+    /** Block height at which the quantum‑resistant PoS algorithm starts. */
+    uint32_t nPoSQuantumHeight = 0;
     uint32_t nHeightEffective; // When these parameters come into use
     struct Params *pLeft = nullptr;      // Left hand branch
     struct Params *pRight = nullptr;     // Right hand branch

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -42,6 +42,7 @@
 
 #include <atomic>
 #include <sstream>
+#include <string>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -202,6 +203,21 @@ public:
         conflictedTxs.clear();
     }
 };
+
+/** Simple Proof‑of‑Stake check. The stake signature must start with
+ *  "POS". When the quantum‑resistant upgrade is active, it must start
+ *  with "QRPOS" instead. */
+static bool CheckProofOfStake(const CBlock& block, bool fQuantum)
+{
+    if (block.vtx.empty() || block.vtx[0]->vin.empty())
+        return false;
+
+    const CScript& sig = block.vtx[0]->vin[0].scriptSig;
+    std::string data(sig.begin(), sig.end());
+    if (fQuantum)
+        return data.rfind("QRPOS", 0) == 0;
+    return data.rfind("POS", 0) == 0;
+}
 
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
 {
@@ -1175,7 +1191,12 @@ static bool ReadBlockOrHeader(T& block, const CDiskBlockPos& pos, const Consensu
 template<typename T>
 static bool ReadBlockOrHeader(T& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams, bool fCheckPOW)
 {
-    if (!ReadBlockOrHeader(block, pindex->GetBlockPos(), consensusParams, fCheckPOW))
+    bool check = fCheckPOW;
+    if (fCheckPOW && consensusParams.nPoSSwitchHeight != 0 &&
+        pindex->nHeight >= (int)consensusParams.nPoSSwitchHeight + 1)
+        check = false;
+
+    if (!ReadBlockOrHeader(block, pindex->GetBlockPos(), consensusParams, check))
         return false;
     if (block.GetHash() != pindex->GetBlockHash())
         return error("ReadBlockOrHeader(CBlock&, CBlockIndex*): GetHash() doesn't match index for %s at %s",
@@ -3031,9 +3052,22 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
         return state.DoS(1, error("%s: forked chain older than max reorganization depth (height %d), with connections (count %d), and (initial download %s)", __func__, nHeight, g_connman ? g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) : -1, IsInitialBlockDownload() ? "true" : "false"), REJECT_MAXREORGDEPTH, "bad-fork-prior-to-maxreorgdepth");
     
 
-    // Check proof of work
-    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
-        return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
+    // Check proof of work or proof of stake after the switch height
+    bool fPoSActive = consensusParams.nPoSSwitchHeight != 0 &&
+                      nHeight >= (int)consensusParams.nPoSSwitchHeight + 1;
+    if (fPoSActive) {
+        bool fQuantum = consensusParams.nPoSQuantumHeight != 0 &&
+                        nHeight >= (int)consensusParams.nPoSQuantumHeight;
+        if (!CheckProofOfStake(block, fQuantum))
+            return state.DoS(100, false, REJECT_INVALID,
+                             fQuantum ? "bad-qrpos" : "bad-pos",
+                             false,
+                             fQuantum ? "incorrect quantum pos signature" :
+                                        "incorrect proof of stake");
+    } else {
+        if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
+            return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
+    }
 
     // Check timestamp against prev
     if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2091,6 +2091,28 @@ UniValue walletlock(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+UniValue stakeprux(const JSONRPCRequest& request)
+{
+    if (!EnsureWalletIsAvailable(request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+            "stakeprux\n"
+            "\nBegin staking PRUX with the wallet's available balance.\n"
+            "\nResult:\n"
+            "\"started\" (string) if staking was enabled\n"
+            "\nExamples:\n"
+            + HelpExampleCli("stakeprux", "") +
+            "\nAs a json rpc call\n" +
+            HelpExampleRpc("stakeprux", "")
+        );
+
+    EnsureWalletIsUnlocked();
+    StartStaking();
+    return UniValue("started");
+}
+
 
 UniValue encryptwallet(const JSONRPCRequest& request)
 {
@@ -3070,6 +3092,8 @@ static const CRPCCommand commands[] =
     { "wallet",             "settxfee",                 &settxfee,                 true,   {"amount"} },
     { "wallet",             "signmessage",              &signmessage,              true,   {"address","message"} },
     { "wallet",             "walletlock",               &walletlock,               true,   {} },
+    { "wallet",             "stakeprux",               &stakeprux,
+   true,   {} },
     { "wallet",             "walletpassphrasechange",   &walletpassphrasechange,   true,   {"oldpassphrase","newpassphrase"} },
     { "wallet",             "walletpassphrase",         &walletpassphrase,         true,   {"passphrase","timeout"} },
     { "wallet",             "removeprunedfunds",        &removeprunedfunds,        true,   {"txid"} },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -42,6 +42,22 @@ unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = DEFAULT_SPEND_ZEROCONF_CHANGE;
 bool fSendFreeTransactions = DEFAULT_SEND_FREE_TRANSACTIONS;
 bool fWalletRbf = DEFAULT_WALLET_RBF;
+bool fStakingActive = false;
+
+void StartStaking()
+{
+    fStakingActive = true;
+}
+
+void StopStaking()
+{
+    fStakingActive = false;
+}
+
+bool IsStaking()
+{
+    return fStakingActive;
+}
 
 const char * DEFAULT_WALLET_DAT = "wallet.dat";
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -42,6 +42,11 @@ extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fSendFreeTransactions;
 extern bool fWalletRbf;
+extern bool fStakingActive;
+
+void StartStaking();
+void StopStaking();
+bool IsStaking();
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
 //! -paytxfee default


### PR DESCRIPTION
## Summary
- add PoS quantum height consensus parameter
- use a new proof-of-stake check that supports a quantum version
- disable PoW checks once PoS is active
- expose `stakeprux` RPC command to start staking
- maintain staking state in the wallet

## Testing
- `make` *(fails: `No targets specified and no makefile found`)*