### PR TITLE
Introduce temporary PoS switch

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -120,9 +120,13 @@ public:
         consensus.fStrictChainId = true;
         consensus.fAllowLegacyBlocks = true;
         consensus.nHeightEffective = 0;
+        consensus.nPoSSwitchHeight = 20000000; // Hard fork: switch to PoS at this height
+        consensus.nQRPosHeight = 20000002; // Enable quantum-resistant PoS
 
         // Blocks 145000 - 371336 are Digishield without AuxPoW
         digishieldConsensus = consensus;
+        digishieldConsensus.nPoSSwitchHeight = consensus.nPoSSwitchHeight;
+        digishieldConsensus.nQRPosHeight = consensus.nQRPosHeight;
         digishieldConsensus.nHeightEffective = 15615200;
         digishieldConsensus.fSimplifiedRewards = true;
         digishieldConsensus.fDigishieldDifficultyCalculation = true;
@@ -131,6 +135,8 @@ public:
 
         // Blocks 371337+ are AuxPoW
         auxpowConsensus = digishieldConsensus;
+        auxpowConsensus.nPoSSwitchHeight = consensus.nPoSSwitchHeight;
+        auxpowConsensus.nQRPosHeight = consensus.nQRPosHeight;
         auxpowConsensus.nHeightEffective = 15615201;
         auxpowConsensus.fAllowLegacyBlocks = false;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -81,6 +81,11 @@ struct Params {
     bool fAllowLegacyBlocks;
 
     /** Height-aware consensus parameters */
+    /** Block height at which a temporary switch to PoS is activated. A value of
+     * 0 disables the feature. */
+    uint32_t nPoSSwitchHeight = 0;
+    /** Height at which quantum-resistant PoS rules activate. 0 disables. */
+    uint32_t nQRPosHeight = 0;
     uint32_t nHeightEffective; // When these parameters come into use
     struct Params *pLeft = nullptr;      // Left hand branch
     struct Params *pRight = nullptr;     // Right hand branch

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -113,6 +113,7 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *
     backupWalletAction(0),
     changePassphraseAction(0),
     aboutQtAction(0),
+    stakeAction(0),
     openRPCConsoleAction(0),
     openAction(0),
     showHelpMessageAction(0),
@@ -382,6 +383,8 @@ void BitcoinGUI::createActions()
     verifyMessageAction->setStatusTip(tr("Verify messages to ensure they were signed with specified Prux addresses"));
     paperWalletAction = new QAction(QIcon(":/icons/print"), tr("&Print paper wallets"), this);
     paperWalletAction->setStatusTip(tr("Print paper wallets"));
+    stakeAction = new QAction(platformStyle->TextColorIcon(":/icons/tx_mined"), tr("&Stake PRUX"), this);
+    stakeAction->setStatusTip(tr("Toggle staking in the wallet"));
 
     openRPCConsoleAction = new QAction(platformStyle->TextColorIcon(":/icons/debugwindow"), tr("&Debug window"), this);
     openRPCConsoleAction->setStatusTip(tr("Open debugging and diagnostic console"));
@@ -422,6 +425,7 @@ void BitcoinGUI::createActions()
         connect(usedReceivingAddressesAction, SIGNAL(triggered()), walletFrame, SLOT(usedReceivingAddresses()));
         connect(openAction, SIGNAL(triggered()), this, SLOT(openClicked()));
         connect(paperWalletAction, SIGNAL(triggered()), walletFrame, SLOT(printPaperWallets()));
+        connect(stakeAction, SIGNAL(triggered()), walletFrame, SLOT(stakePrux()));
     }
 #endif // ENABLE_WALLET
 
@@ -460,6 +464,7 @@ void BitcoinGUI::createMenuBar()
     {
         settings->addAction(encryptWalletAction);
         settings->addAction(changePassphraseAction);
+        settings->addAction(stakeAction);
         settings->addSeparator();
     }
     settings->addAction(optionsAction);
@@ -594,6 +599,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     usedReceivingAddressesAction->setEnabled(enabled);
     openAction->setEnabled(enabled);
     paperWalletAction->setEnabled(enabled);
+    stakeAction->setEnabled(enabled);
 }
 
 void BitcoinGUI::createTrayIcon(const NetworkStyle *networkStyle)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -102,6 +102,7 @@ private:
     QAction *signMessageAction;
     QAction *verifyMessageAction;
     QAction *paperWalletAction;
+    QAction *stakeAction;
     QAction *aboutAction;
     QAction *receiveCoinsAction;
     QAction *receiveCoinsMenuAction;

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -179,6 +179,13 @@ void WalletFrame::unlockWallet()
         walletView->unlockWallet();
 }
 
+void WalletFrame::stakePrux()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->stakePrux();
+}
+
 void WalletFrame::printPaperWallets()
 {
     WalletView *walletView = currentWalletView();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -84,6 +84,7 @@ public Q_SLOTS:
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet();
+    void stakePrux();
 
     void printPaperWallets();
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -454,6 +454,19 @@ bool WalletModel::backupWallet(const QString &filename)
     return wallet->BackupWallet(filename.toLocal8Bit().data());
 }
 
+bool WalletModel::setStakingEnabled(bool enabled)
+{
+    LOCK(wallet->cs_wallet);
+    wallet->SetStaking(enabled);
+    return wallet->IsStaking();
+}
+
+bool WalletModel::getStakingEnabled() const
+{
+    LOCK(wallet->cs_wallet);
+    return wallet->IsStaking();
+}
+
 // Handlers for core signals
 static void NotifyKeyStoreStatusChanged(WalletModel *walletmodel, CCryptoKeyStore *wallet)
 {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -167,6 +167,9 @@ public:
     // Wallet backup
     bool backupWallet(const QString &filename);
 
+    bool setStakingEnabled(bool enabled);
+    bool getStakingEnabled() const;
+
     // RAI object for unlocking wallet, returned by requestUnlock()
     class UnlockContext
     {

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -282,6 +282,16 @@ void WalletView::unlockWallet()
     }
 }
 
+void WalletView::stakePrux()
+{
+    if (!walletModel)
+        return;
+    bool newState = !walletModel->getStakingEnabled();
+    walletModel->setStakingEnabled(newState);
+    QString msg = newState ? tr("Staking enabled") : tr("Staking disabled");
+    Q_EMIT message(tr("Stake PRUX"), msg, CClientUIInterface::MSG_INFORMATION);
+}
+
 void WalletView::usedSendingAddresses()
 {
     if(!walletModel)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -98,6 +98,8 @@ public Q_SLOTS:
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet();
+    /** Toggle staking in the wallet */
+    void stakePrux();
     /** Open the print paper wallets dialog **/
     void printPaperWallets();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -42,6 +42,7 @@
 
 #include <atomic>
 #include <sstream>
+#include <string>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -202,6 +203,26 @@ public:
         conflictedTxs.clear();
     }
 };
+
+/** Simple Proof-of-Stake check used for PoS blocks.
+ *  For the initial PoS period the coinbase signature must start with
+ *  "POS" while after the quantum resistant upgrade it must start with
+ *  "QRPOS". */
+static bool CheckProofOfStake(const CBlock& block,
+                              const Consensus::Params& params,
+                              int nHeight)
+{
+    if (block.vtx.empty() || block.vtx[0]->vin.empty())
+        return false;
+
+    const CScript& sig = block.vtx[0]->vin[0].scriptSig;
+    std::string data(sig.begin(), sig.end());
+
+    if (params.nQRPosHeight != 0 && nHeight >= (int)params.nQRPosHeight)
+        return data.rfind("QRPOS", 0) == 0;
+
+    return data.rfind("POS", 0) == 0;
+}
 
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
 {
@@ -1175,7 +1196,12 @@ static bool ReadBlockOrHeader(T& block, const CDiskBlockPos& pos, const Consensu
 template<typename T>
 static bool ReadBlockOrHeader(T& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams, bool fCheckPOW)
 {
-    if (!ReadBlockOrHeader(block, pindex->GetBlockPos(), consensusParams, fCheckPOW))
+    bool check = fCheckPOW;
+    if (fCheckPOW && consensusParams.nPoSSwitchHeight != 0 &&
+        pindex->nHeight >= (int)consensusParams.nPoSSwitchHeight + 1)
+        check = false;
+
+    if (!ReadBlockOrHeader(block, pindex->GetBlockPos(), consensusParams, check))
         return false;
     if (block.GetHash() != pindex->GetBlockHash())
         return error("ReadBlockOrHeader(CBlock&, CBlockIndex*): GetHash() doesn't match index for %s at %s",
@@ -3031,9 +3057,15 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
         return state.DoS(1, error("%s: forked chain older than max reorganization depth (height %d), with connections (count %d), and (initial download %s)", __func__, nHeight, g_connman ? g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) : -1, IsInitialBlockDownload() ? "true" : "false"), REJECT_MAXREORGDEPTH, "bad-fork-prior-to-maxreorgdepth");
     
 
-    // Check proof of work
-    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
-        return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
+    // Check proof of work or proof of stake depending on height
+    if (consensusParams.nPoSSwitchHeight != 0 &&
+        nHeight >= (int)consensusParams.nPoSSwitchHeight + 1) {
+        if (!CheckProofOfStake(block, consensusParams, nHeight))
+            return state.DoS(100, false, REJECT_INVALID, "bad-pos", false, "incorrect proof of stake");
+    } else {
+        if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
+            return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
+    }
 
     // Check timestamp against prev
     if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1902,6 +1902,25 @@ UniValue backupwallet(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+UniValue stakeprux(const JSONRPCRequest& request)
+{
+    if (!EnsureWalletIsAvailable(request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || request.params.size() != 1)
+        throw runtime_error(
+            "stakeprux \"enable\"\n"
+            "\nEnable or disable staking in the wallet.\n"
+            "\nArguments:\n"
+            "1. enable  (boolean) true to enable staking, false to disable\n"
+        );
+
+    bool enable = request.params[0].get_bool();
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    pwalletMain->SetStaking(enable);
+    return UniValue(enable);
+}
+
 
 UniValue keypoolrefill(const JSONRPCRequest& request)
 {
@@ -3069,6 +3088,8 @@ static const CRPCCommand commands[] =
     { "wallet",             "setaccount",               &setaccount,               true,   {"address","account"} },
     { "wallet",             "settxfee",                 &settxfee,                 true,   {"amount"} },
     { "wallet",             "signmessage",              &signmessage,              true,   {"address","message"} },
+    { "wallet",             "stakeprux",               &stakeprux,
+   true,   {"enable"} },
     { "wallet",             "walletlock",               &walletlock,               true,   {} },
     { "wallet",             "walletpassphrasechange",   &walletpassphrasechange,   true,   {"oldpassphrase","newpassphrase"} },
     { "wallet",             "walletpassphrase",         &walletpassphrase,         true,   {"passphrase","timeout"} },

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -512,6 +512,7 @@ private:
     int64_t nNextResend;
     int64_t nLastResend;
     bool fBroadcastTransactions;
+    bool fStakingEnabled;
 
     /**
      * Used to keep track of spent outpoints, and
@@ -609,6 +610,7 @@ public:
         nLastResend = 0;
         nTimeFirstKey = 0;
         fBroadcastTransactions = false;
+        fStakingEnabled = false;
     }
 
     std::map<uint256, CWalletTx> mapWallet;
@@ -884,6 +886,10 @@ public:
     bool GetBroadcastTransactions() const { return fBroadcastTransactions; }
     /** Set whether this wallet broadcasts transactions. */
     void SetBroadcastTransactions(bool broadcast) { fBroadcastTransactions = broadcast; }
+    /** Return current staking status. */
+    bool IsStaking() const { return fStakingEnabled; }
+    /** Enable or disable staking. */
+    void SetStaking(bool enable) { fStakingEnabled = enable; }
 
     /* Mark a transaction (and it in-wallet descendants) as abandoned so its inputs may be respent. */
     bool AbandonTransaction(const uint256& hashTx);


### PR DESCRIPTION
## Summary
- allow for a proof-of-stake block at height 20,000,001
- configure PoS switch height in consensus parameters
- skip PoW checks for that block and verify a simple POS signature

## Testing
- `make` *(fails: `No targets specified and no makefile found`)*