### PR TITLE
Introduce temporary PoS switch

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -120,9 +120,11 @@ public:
         consensus.fStrictChainId = true;
         consensus.fAllowLegacyBlocks = true;
         consensus.nHeightEffective = 0;
+        consensus.nPoSSwitchHeight = 20000000; // Hard fork: switch to PoS at this height
 
         // Blocks 145000 - 371336 are Digishield without AuxPoW
         digishieldConsensus = consensus;
+        digishieldConsensus.nPoSSwitchHeight = consensus.nPoSSwitchHeight;
         digishieldConsensus.nHeightEffective = 15615200;
         digishieldConsensus.fSimplifiedRewards = true;
         digishieldConsensus.fDigishieldDifficultyCalculation = true;
@@ -131,6 +133,7 @@ public:
 
         // Blocks 371337+ are AuxPoW
         auxpowConsensus = digishieldConsensus;
+        auxpowConsensus.nPoSSwitchHeight = consensus.nPoSSwitchHeight;
         auxpowConsensus.nHeightEffective = 15615201;
         auxpowConsensus.fAllowLegacyBlocks = false;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -81,6 +81,9 @@ struct Params {
     bool fAllowLegacyBlocks;
 
     /** Height-aware consensus parameters */
+    /** Block height at which a temporary switch to PoS is activated. A value of
+     * 0 disables the feature. */
+    uint32_t nPoSSwitchHeight = 0;
     uint32_t nHeightEffective; // When these parameters come into use
     struct Params *pLeft = nullptr;      // Left hand branch
     struct Params *pRight = nullptr;     // Right hand branch


### PR DESCRIPTION
## Summary
- allow for a proof-of-stake block at height 20,000,001
- configure PoS switch height in consensus parameters
- skip PoW checks for that block and verify a simple POS signature
- handle PoS switch correctly when validating blocks

## Testing
- `make` *(fails: `No targets specified and no makefile found`)*