### PR TITLE
Improve staking RPCs and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ This is controlled by the `nPoSSwitchHeight` consensus parameter.  For that
 block, proof-of-work validation is skipped and the coinbase transaction must
 start with `POS`.
 
+### Additional staking features
+
+Blocks at height **20,000,002** and above use a quantum-resistant
+Proof-of-Stake algorithm.  When this upgrade is active, the coinbase
+signature must start with `QRPOS`.
+
+The wallet exposes a `stakeprux` RPC to start staking with the current
+balance.  The same functionality is available through the Qt wallet
+interface.
+Staking can be disabled with the `stopstaking` RPC and the current
+status checked via `isstaking`.
+
+To accommodate more transactions per block, the default maximum block
+size is **9,590,000 bytes**.
+
 - **Website:** [prux.info.](https://prux.info)
 
 ## License 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2113,6 +2113,47 @@ UniValue stakeprux(const JSONRPCRequest& request)
     return UniValue("started");
 }
 
+UniValue stopstaking(const JSONRPCRequest& request)
+{
+    if (!EnsureWalletIsAvailable(request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+            "stopstaking\n"
+            "\nStop staking PRUX with the wallet's available balance.\n"
+            "\nResult:\n"
+            "\"stopped\" (string) if staking was disabled\n"
+            "\nExamples:\n"
+            + HelpExampleCli("stopstaking", "") +
+            "\nAs a json rpc call\n" +
+            HelpExampleRpc("stopstaking", "")
+        );
+
+    StopStaking();
+    return UniValue("stopped");
+}
+
+UniValue isstaking(const JSONRPCRequest& request)
+{
+    if (!EnsureWalletIsAvailable(request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+            "isstaking\n"
+            "\nReturns true if the wallet is currently staking.\n"
+            "\nResult:\n"
+            "true|false (boolean)\n"
+            "\nExamples:\n"
+            + HelpExampleCli("isstaking", "") +
+            "\nAs a json rpc call\n" +
+            HelpExampleRpc("isstaking", "")
+        );
+
+    return UniValue(IsStaking());
+}
+
 
 UniValue encryptwallet(const JSONRPCRequest& request)
 {
@@ -3093,6 +3134,10 @@ static const CRPCCommand commands[] =
     { "wallet",             "signmessage",              &signmessage,              true,   {"address","message"} },
     { "wallet",             "walletlock",               &walletlock,               true,   {} },
     { "wallet",             "stakeprux",               &stakeprux,
+   true,   {} },
+    { "wallet",             "stopstaking",             &stopstaking,
+   true,   {} },
+    { "wallet",             "isstaking",               &isstaking,
    true,   {} },
     { "wallet",             "walletpassphrasechange",   &walletpassphrasechange,   true,   {"oldpassphrase","newpassphrase"} },
     { "wallet",             "walletpassphrase",         &walletpassphrase,         true,   {"passphrase","timeout"} },


### PR DESCRIPTION
## Summary
- add `stopstaking` RPC to turn off staking
- add `isstaking` RPC to check staking state
- document new staking RPCs

## Testing
- `make check` *(fails: No rule to make target 'check')*