### PR TITLE
Improve README with staking info

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,13 +1,13 @@
-name: '[FULL] ubuntu-18.04.'
+name: '[FULL] ubuntu-22.04'
 
 on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         
       - name: Update apt repos
         run: sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ This is controlled by the `nPoSSwitchHeight` consensus parameter.  For that
 block, proof-of-work validation is skipped and the coinbase transaction must
 start with `POS`.
 
+### Additional staking features
+
+Blocks at height **20,000,002** and above use a quantum-resistant
+Proof-of-Stake algorithm.  When this upgrade is active, the coinbase
+signature must start with `QRPOS`.
+
+The wallet exposes a `stakeprux` RPC to start staking with the current
+balance.  The same functionality is available through the Qt wallet
+interface.
+Staking can be halted again via the `stopstaking` RPC, and the current
+status may be queried with `isstaking`.
+
+To accommodate more transactions per block, the default maximum block
+size is **9,590,000 bytes**.
+
 - **Website:** [prux.info.](https://prux.info)
 
 ## License 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2105,12 +2105,61 @@ UniValue stakeprux(const JSONRPCRequest& request)
             "\nExamples:\n"
             + HelpExampleCli("stakeprux", "") +
             "\nAs a json rpc call\n" +
+    { "wallet",             "stopstaking",             &stopstaking,
+   true,   {} },
+    { "wallet",             "isstaking",               &isstaking,
+   true,   {} },
             HelpExampleRpc("stakeprux", "")
         );
+    { "wallet",             "stopstaking",             &stopstaking,
+   true,   {} },
+    { "wallet",             "isstaking",               &isstaking,
+   true,   {} },
 
     EnsureWalletIsUnlocked();
     StartStaking();
     return UniValue("started");
+}
+
+UniValue stopstaking(const JSONRPCRequest& request)
+{
+    if (!EnsureWalletIsAvailable(request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+            "stopstaking\n"
+            "\nDisable staking of PRUX blocks.\n"
+            "\nResult:\n"
+            "\"stopped\" (string) if staking was disabled\n"
+            "\nExamples:\n"
+            + HelpExampleCli("stopstaking", "") +
+            "\nAs a json rpc call\n" +
+            HelpExampleRpc("stopstaking", "")
+        );
+
+    StopStaking();
+    return UniValue("stopped");
+}
+
+UniValue isstaking(const JSONRPCRequest& request)
+{
+    if (!EnsureWalletIsAvailable(request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+            "isstaking\n"
+            "\nReturns whether the wallet is currently staking.\n"
+            "\nResult:\n"
+            "true|false\n"
+            "\nExamples:\n"
+            + HelpExampleCli("isstaking", "") +
+            "\nAs a json rpc call\n" +
+            HelpExampleRpc("isstaking", "")
+        );
+
+    return UniValue(IsStaking());
 }
 
 
@@ -3093,6 +3142,10 @@ static const CRPCCommand commands[] =
     { "wallet",             "signmessage",              &signmessage,              true,   {"address","message"} },
     { "wallet",             "walletlock",               &walletlock,               true,   {} },
     { "wallet",             "stakeprux",               &stakeprux,
+   true,   {} },
+    { "wallet",             "stopstaking",             &stopstaking,
+   true,   {} },
+    { "wallet",             "isstaking",               &isstaking,
    true,   {} },
     { "wallet",             "walletpassphrasechange",   &walletpassphrasechange,   true,   {"oldpassphrase","newpassphrase"} },
     { "wallet",             "walletpassphrase",         &walletpassphrase,         true,   {"passphrase","timeout"} },


### PR DESCRIPTION
## Summary
- document the quantum-resistant PoS activation
- describe how to start staking from RPC/Qt
- note the large default block size for high throughput
- add `stopstaking` and `isstaking` RPCs and register them
- update CI workflow to Ubuntu 22.04

## Testing
- `make check` *(fails: No rule to make target 'check')*